### PR TITLE
Two minor changes

### DIFF
--- a/src/main/java/org/mitre/provenance/plusobject/ProvenanceCollection.java
+++ b/src/main/java/org/mitre/provenance/plusobject/ProvenanceCollection.java
@@ -489,6 +489,7 @@ public class ProvenanceCollection implements Cloneable {
 		Map<String,PLUSObject> on = other.nodes;
 		Map<String,PLUSEdge> oe = other.edges;
 		Map<String,NonProvenanceEdge> npes = other.npes;
+		Map<String,PLUSActor> oa = other.actors;
 		
 		for(String k : on.keySet()) {
 			if(addNode(on.get(k), force)) itemsAdded++;  
@@ -497,6 +498,11 @@ public class ProvenanceCollection implements Cloneable {
 		for(String k : oe.keySet()) {
 			if(addEdge(oe.get(k), force)) itemsAdded++; 
 		}
+		
+		for(String k : oa.keySet()) { 
+			if(addActor(oa.get(k), force)) itemsAdded++;
+		}
+		
 		
 		for(String k : npes.keySet()) { 
 			if(addNonProvenanceEdge(npes.get(k), force)) itemsAdded++;

--- a/src/main/java/org/mitre/provenance/services/DAGServices.java
+++ b/src/main/java/org/mitre/provenance/services/DAGServices.java
@@ -155,7 +155,10 @@ public class DAGServices {
 			}
 		}
 		
-		if(reasons.length() > 0) throw new CollectionFormatException(reasons.toString());
+		// [piekutsj] Commenting out the exception, keeping the warnings.  This action subject to revision at a later time, but for now,
+		// after some discussion it was decided that it would be best if REST actions were consistent to how local behaves, 
+		// i.e., skip duplicate node, with warning.
+		//if(reasons.length() > 0) throw new CollectionFormatException(reasons.toString());
 		
 		return col;
 	} // End checkGraphFormat


### PR DESCRIPTION
ProvenanceCollection.java:  Just added what looked like an oversight with Actors in "addAll".

DAGServices.java:  Commenting out the exception, keeping the warnings.  This action subject to revision at a later time, but for now, it was decided that it would be best if REST actions were consistent to how local behaves, i.e., skip duplicate node, with warning.  


Sarah  Piekut

